### PR TITLE
Remove blank and comment lines

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -179,6 +179,9 @@ sed -i s~__ETCD_ENDPOINTS__~"${ETCD_ENDPOINTS:-}"~g $TMP_CONF
 sed -i s~__ETCD_DISCOVERY_SRV__~"${ETCD_DISCOVERY_SRV:-}"~g $TMP_CONF
 sed -i s~__LOG_LEVEL__~"${LOG_LEVEL:-warn}"~g $TMP_CONF
 
+# Remove blank and comment lines
+sed -i '/^$/d;/^#/d' $TMP_CONF
+
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-calico.conf}
 CNI_OLD_CONF_NAME=${CNI_OLD_CONF_NAME:-10-calico.conf}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Remove blank and comment lines before `mv "$TMP_CONF" /host/etc/cni/net.d/"${CNI_CONF_NAME}"`.
This has the benefit of allowing comments and blank lines in the TMP_CONF file.

In some situations, I have to use `ansible` to update `calico-cni`'s config file, but it might add some comment lines automatically, this will cause error: `error parsing configuration list: invalid character '#' looking for beginning of object key string`. So I want to remove blank and comment lines before convert temp file to target file.

I have tested the effect of command `sed -i '/^$/d;/^#/d'` as follows:
```shell
root@master1:[/root]cat test_file 
#This is a comment line
1234

5678
foo
#Another comment line
bar
root@master1:[/root]sed -i '/^$/d;/^#/d' test_file 
root@master1:[/root]cat test_file 
1234
5678
foo
bar
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
